### PR TITLE
Show estimated reading time of given article

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ terminal_mode: false
 opml_file_path: 
 markdown_file_prefix: 
 markdown_file_suffix: 
+reading_time: false
 openai_api_key: 
 summary_feeds: 
 ```

--- a/config.go
+++ b/config.go
@@ -31,7 +31,8 @@ weather_longitude: 122.41
 terminal_mode: false
 opml_file_path: 
 markdown_file_prefix: 
-markdown_file_suffix: 
+markdown_file_suffix:
+reading_time: false 
 openai_api_key: 
 summary_feeds: `
 
@@ -165,6 +166,7 @@ func bootstrapConfig() {
 	}
 
 	instapaper = viper.GetBool("instapaper")
+	reading_time = viper.GetBool("reading_time")
 
 	// Overwrite terminal_mode from config file only if its not set through -t flag
 	if !terminal_mode {

--- a/main.go
+++ b/main.go
@@ -67,11 +67,8 @@ func getReadingTime(link string) string {
 
 	// assuming average reading time is 200 words per minute calculate reading time of the article
 	readingTime := float64(len(words)) / float64(200)
-
-	// round it to full integer minutes
 	minutes := int(readingTime)
 
-	// concatenate the minutes to a string and return
 	return strconv.Itoa(minutes) + " min"
 }
 


### PR DESCRIPTION
New option in config.yaml called "reading_time", if its set to true user will get an estimated reading time of given article.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/3144671/221375306-1451043c-5514-4989-9fc3-500e6e34dbdd.png">
