### PR TITLE
feat: switch to GPT3.5 for cost savings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/go-shiori/dom v0.0.0-20210627111528-4e4722cd0d65 // indirect
 	github.com/gogs/chardet v0.0.0-20191104214054-4b6791f73a28 // indirect
+	github.com/sashabaranov/go-openai v1.9.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sashabaranov/go-gpt3 v1.0.1 h1:KHwY4uroFlX1qI1Hui7d31ZI6uzbNGL9zAkh1FkfhuM=
 github.com/sashabaranov/go-gpt3 v1.0.1/go.mod h1:BIZdbwdzxZbCrcKGMGH6u2eyGe1xFuX9Anmh3tCP8lQ=
+github.com/sashabaranov/go-openai v1.9.0 h1:NoiO++IISxxJ1pRc0n7uZvMGMake0G+FJ1XPwXtprsA=
+github.com/sashabaranov/go-openai v1.9.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/savioxavier/termlink v1.2.1 h1:O9ZQvk9BPQQK4JQeMB56ZfV8uam0Ts+f97mJme7+dq8=
 github.com/savioxavier/termlink v1.2.1/go.mod h1:WA7FTALNwN41NGnmQMIrnjAYTsEhIAZ4RuzgEiB0Jp8=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,6 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sashabaranov/go-gpt3 v1.0.1 h1:KHwY4uroFlX1qI1Hui7d31ZI6uzbNGL9zAkh1FkfhuM=
-github.com/sashabaranov/go-gpt3 v1.0.1/go.mod h1:BIZdbwdzxZbCrcKGMGH6u2eyGe1xFuX9Anmh3tCP8lQ=
 github.com/sashabaranov/go-openai v1.9.0 h1:NoiO++IISxxJ1pRc0n7uZvMGMake0G+FJ1XPwXtprsA=
 github.com/sashabaranov/go-openai v1.9.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/savioxavier/termlink v1.2.1 h1:O9ZQvk9BPQQK4JQeMB56ZfV8uam0Ts+f97mJme7+dq8=

--- a/summarize.go
+++ b/summarize.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	readability "github.com/go-shiori/go-readability"
-	gogpt "github.com/sashabaranov/go-gpt3"
+	openai "github.com/sashabaranov/go-openai"
 )
 
 func getSummaryFromLink(url string) string {
@@ -31,11 +31,11 @@ func summarize(text string) string {
 	if len(text) < 200 {
 		return ""
 	}
-	c := gogpt.NewClient(openaiApiKey)
+	c := openai.NewClient(openaiApiKey)
 	ctx := context.Background()
 
-	req := gogpt.CompletionRequest{
-		Model:     gogpt.GPT3TextDavinci003,
+	req := openai.CompletionRequest{
+		Model:     openai.GPT3Dot5Turbo,
 		MaxTokens: 60,
 		Prompt:    text + " \n\nTl;dr",
 	}

--- a/summarize.go
+++ b/summarize.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	readability "github.com/go-shiori/go-readability"
@@ -31,23 +30,29 @@ func summarize(text string) string {
 	if len(text) < 200 {
 		return ""
 	}
-	c := openai.NewClient(openaiApiKey)
-	ctx := context.Background()
 
-	req := openai.CompletionRequest{
-		Model:     openai.GPT3Dot5Turbo,
-		MaxTokens: 60,
-		Prompt:    text + " \n\nTl;dr",
-	}
-	resp, err := c.CreateCompletion(ctx, req)
+	client := openai.NewClient(openaiApiKey)
+	resp, err := client.CreateChatCompletion(
+		context.Background(),
+		openai.ChatCompletionRequest{
+			Model: openai.GPT3Dot5Turbo,
+			Messages: []openai.ChatCompletionMessage{
+				{
+					Role:    openai.ChatMessageRoleAssistant,
+					Content: "Summarize the following text:",
+				},
+				{
+					Role:    openai.ChatMessageRoleUser,
+					Content: text,
+				},
+			},
+		},
+	)
+
 	if err != nil {
+		fmt.Printf("ChatCompletion error: %v\n", err)
 		return ""
 	}
 
-	// append ... if text does not end with .
-	if !strings.HasSuffix(resp.Choices[0].Text, ".") {
-		resp.Choices[0].Text = resp.Choices[0].Text + "..."
-	}
-
-	return resp.Choices[0].Text
+	return resp.Choices[0].Message.Content
 }


### PR DESCRIPTION
According to https://openai.com/pricing pricing for GPT3 is $0.02/1k tokens, while GPT3.5 is $0.002/1k tokens (10x cheaper).
This bumps the version of the library used in order to access GPT3.5 as well