### PR TITLE
feat: Add config param to specify how long the google news feed is

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ feeds:
   - http://www.joelonsoftware.com/rss.xml
   - https://www.youtube.com/feeds/videos.xml?channel_id=UCHnyfMqiRRG1u-2MsSQLbXA
 google_news_keywords: George Hotz,ChatGPT,Copenhagen
+google_news_length: 5
 instapaper: true
 weather_latitude: 37.77
 weather_longitude: 122.41

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ feeds:
   - http://www.joelonsoftware.com/rss.xml
   - https://www.youtube.com/feeds/videos.xml?channel_id=UCHnyfMqiRRG1u-2MsSQLbXA
 google_news_keywords: George Hotz,ChatGPT,Copenhagen
+google_news_length: 5
 instapaper: true
 weather_latitude: 37.77
 weather_longitude: 122.41
@@ -151,7 +152,13 @@ func bootstrapConfig() {
 		googleNewsKeywords := url.QueryEscape(viper.Get("google_news_keywords").(string))
 		if googleNewsKeywords != "" {
 			googleNewsUrl := "https://news.google.com/rss/search?hl=en-US&gl=US&ceid=US%3Aen&oc=11&q=" + strings.Join(strings.Split(googleNewsKeywords, "%2C"), "%20%7C%20")
-			myFeeds = append(myFeeds, RSS{url: googleNewsUrl, limit: 15}) // #FIXME make it configurable
+			var googleNewsLength int
+			if viper.IsSet("google_news_length") {
+				googleNewsLength = viper.Get("google_news_length").(int)
+			} else {
+				googleNewsLength = 15 // limit
+			}
+			myFeeds = append(myFeeds, RSS{url: googleNewsUrl, limit: googleNewsLength})
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -156,7 +156,7 @@ func bootstrapConfig() {
 			if viper.IsSet("google_news_length") {
 				googleNewsLength = viper.Get("google_news_length").(int)
 			} else {
-				googleNewsLength = 15 // limit
+				googleNewsLength = 15 // default limit
 			}
 			myFeeds = append(myFeeds, RSS{url: googleNewsUrl, limit: googleNewsLength})
 		}


### PR DESCRIPTION
## Changes
Added `google_news_length`, a parameter in `config.yaml` which allows the user to specify how long the Google News feed should be.