### PR TITLE
add configurable summarize prompt

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ openai_api_key:
 openai_base_url:
 openai_model:
 summary_feeds:
+summary_prompt:
 show_images: false
 analyst_feeds:
   - https://feeds.bbci.co.uk/news/business/rss.xml

--- a/config.go
+++ b/config.go
@@ -138,7 +138,9 @@ func bootstrapConfig() {
 	if viper.IsSet("openai_model") {
 		openaiModel = viper.Get("openai_model").(string)
 	}
-
+	if viper.IsSet("summary_prompt") {
+		summaryPrompt = viper.Get("summary_prompt").(string)
+	}
 	if viper.IsSet("summary_feeds") {
 		summaryFeeds := viper.Get("summary_feeds")
 

--- a/config.go
+++ b/config.go
@@ -147,11 +147,12 @@ func bootstrapConfig() {
 			myFeeds = append(myFeeds, RSS{url: url, limit: limit, summarize: true})
 		}
 	}
-
-	for _, feed := range feeds.([]any) {
-		url, limit := getFeedAndLimit(feed.(string))
-		myFeeds = append(myFeeds, RSS{url: url, limit: limit})
-	}
+	if feeds != nil {
+			for _, feed := range feeds.([]any) {
+				url, limit := getFeedAndLimit(feed.(string))
+				myFeeds = append(myFeeds, RSS{url: url, limit: limit})
+			}
+		}
 
 	if viper.IsSet("google_news_keywords") {
 		googleNewsKeywords := url.QueryEscape(viper.Get("google_news_keywords").(string))

--- a/feeds_writer.go
+++ b/feeds_writer.go
@@ -28,6 +28,7 @@ var show_images bool
 var sunrise_sunset bool
 var myFeeds []RSS
 var db *sql.DB
+var summaryPrompt string
 
 type RSS struct {
 	url       string

--- a/summarize.go
+++ b/summarize.go
@@ -32,9 +32,9 @@ func summarize(text string) string {
 		return ""
 	}
 	
-	summaryPrompt := viper.GetString("summary_prompt")
-	if summaryPrompt == "" {
-		summaryPrompt = "Summarize the following text:"
+	prompt := summaryPrompt
+	if prompt == "" {
+		prompt = "Summarize the following text:"
 	}
 	
 	clientConfig := openai.DefaultConfig(openaiApiKey)
@@ -53,7 +53,7 @@ func summarize(text string) string {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role:    openai.ChatMessageRoleAssistant,
-					Content: summaryPrompt,
+					Content: prompt,
 				},
 				{
 					Role:    openai.ChatMessageRoleUser,

--- a/summarize.go
+++ b/summarize.go
@@ -7,6 +7,7 @@ import (
 
 	readability "github.com/go-shiori/go-readability"
 	openai "github.com/sashabaranov/go-openai"
+	"github.com/spf13/viper"
 )
 
 func getSummaryFromLink(url string) string {
@@ -30,6 +31,12 @@ func summarize(text string) string {
 	if len(text) < 200 {
 		return ""
 	}
+	
+	summaryPrompt := viper.GetString("summary_prompt")
+	if summaryPrompt == "" {
+		summaryPrompt = "Summarize the following text:"
+	}
+	
 	clientConfig := openai.DefaultConfig(openaiApiKey)
 	if openaiBaseURL != "" {
 		clientConfig.BaseURL = openaiBaseURL
@@ -46,7 +53,7 @@ func summarize(text string) string {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role:    openai.ChatMessageRoleAssistant,
-					Content: "Summarize the following text:",
+					Content: summaryPrompt,
 				},
 				{
 					Role:    openai.ChatMessageRoleUser,


### PR DESCRIPTION
Sometimes you want the summary in a particular format: n number of words, with or without bullet points, etc.

I also added a check for empty values in the `feeds` key. Sometimes one may not want a regular feed list, only summaries or analyses.